### PR TITLE
Add a ExpandoObjectConverter to enable deserialization of a SmartContract

### DIFF
--- a/AtomicCore.BlockChain.TronNet/Infrastructure/ABI/JsonDeserialisation/ABIDeserialiser.cs
+++ b/AtomicCore.BlockChain.TronNet/Infrastructure/ABI/JsonDeserialisation/ABIDeserialiser.cs
@@ -141,7 +141,7 @@ namespace AtomicCore.BlockChain.TronNet
         /// <returns></returns>
         public ContractABI DeserialiseContract(string abi)
         {
-            List<IDictionary<string, object>> contract = Newtonsoft.Json.JsonConvert.DeserializeObject<List<IDictionary<string, object>>>(abi);
+            List<IDictionary<string, object>> contract = Newtonsoft.Json.JsonConvert.DeserializeObject<List<IDictionary<string, object>>>(abi, new ExpandoObjectConverter());
 
             return DeserialiseContractBody(contract);
         }

--- a/AtomicCore.BlockChain.TronNet/Infrastructure/ABI/JsonDeserialisation/ExpandoObjectConverter.cs
+++ b/AtomicCore.BlockChain.TronNet/Infrastructure/ABI/JsonDeserialisation/ExpandoObjectConverter.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AtomicCore.BlockChain.TronNet
+{
+    /// <summary>
+    ///     This is a replication (copy) of Newtonsoft ExpandoObjectConverter to allow for PCL compilaton
+    /// </summary>
+    public class ExpandoObjectConverter : JsonConverter
+    {
+        /// <summary>
+        ///     Gets a value indicating whether this <see cref="JsonConverter" /> can write JSON.
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> if this <see cref="JsonConverter" /> can write JSON; otherwise, <c>false</c>.
+        /// </value>
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        /// <summary>
+        ///     Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        ///     <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IDictionary<string, object>);
+        }
+
+        /// <summary>
+        ///     Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader" /> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            return ReadValue(reader);
+        }
+
+        /// <summary>
+        ///     Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter" /> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            // can write is set to false
+        }
+
+        private bool IsPrimitiveToken(JsonToken token)
+        {
+            switch (token)
+            {
+                case JsonToken.Integer:
+                case JsonToken.Float:
+                case JsonToken.String:
+                case JsonToken.Boolean:
+                case JsonToken.Undefined:
+                case JsonToken.Null:
+                case JsonToken.Date:
+                case JsonToken.Bytes:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private object ReadList(JsonReader reader)
+        {
+            IList<object> list = new List<object>();
+
+            while (reader.Read())
+                switch (reader.TokenType)
+                {
+                    case JsonToken.Comment:
+                        break;
+                    default:
+                        var v = ReadValue(reader);
+
+                        list.Add(v);
+                        break;
+                    case JsonToken.EndArray:
+                        return list;
+                }
+
+            throw new Exception("Unexpected end.");
+        }
+
+        private object ReadObject(JsonReader reader)
+        {
+            IDictionary<string, object> expandoObject = new Dictionary<string, object>();
+
+            while (reader.Read())
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        var propertyName = reader.Value.ToString();
+
+                        if (!reader.Read())
+                            throw new Exception("Unexpected end.");
+
+                        var v = ReadValue(reader);
+
+                        expandoObject[propertyName] = v;
+                        break;
+                    case JsonToken.Comment:
+                        break;
+                    case JsonToken.EndObject:
+                        return expandoObject;
+                }
+
+            throw new Exception("Unexpected end.");
+        }
+
+        private object ReadValue(JsonReader reader)
+        {
+            while (reader.TokenType == JsonToken.Comment)
+                if (!reader.Read())
+                    throw new Exception("Unexpected end.");
+
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartObject:
+                    return ReadObject(reader);
+                case JsonToken.StartArray:
+                    return ReadList(reader);
+                default:
+                    if (IsPrimitiveToken(reader.TokenType))
+                        return reader.Value;
+
+                    throw new Exception("Unexpected token when converting ExpandoObject");
+            }
+        }
+    }
+
+    // Converting ABI as JArray, JObject into ExpandoObject style
+    // This is only available for ABI, not generic JObject/ExpandoObject conversion
+    public class JObjectToExpandoConverter {
+        public List<IDictionary<string, object>> JObjectArray(JArray array) {
+            var l = new List<IDictionary<string, object>>();
+            foreach(JObject obj in array)
+                l.Add(JObject(obj));
+            return l;
+        }
+        public List<object> JArray(JArray array) {
+            var l = new List<object>();
+            foreach(JToken token in array)
+                l.Add(JToken(token));
+            return l;
+        }
+        public IDictionary<string, object> JObject(JObject obj) {
+            var dic = new Dictionary<string, object>();
+            foreach(var pair in obj) {
+                dic[pair.Key] = JToken(pair.Value);
+            }
+            return dic;
+        }
+        public object JToken(JToken token)
+        {
+            if(token is JObject)
+                return JObject((JObject)token);
+            if(token is JArray)
+                return JArray((JArray)token);
+            if(token.Type == JTokenType.String)
+                return token.Value<string>();
+            if(token.Type == JTokenType.Boolean)
+                return token.Value<bool>();
+            if(token.Type == JTokenType.Integer)
+                return token.Value<int>();
+            throw new Exception("unexpected token type " + token.Type);
+        }
+    }
+}

--- a/AtomicCore.BlockChain.TronNetUnitTest/Infrastructure/ABI/JsonDeserialisation/AbiDeserialiserTests.cs
+++ b/AtomicCore.BlockChain.TronNetUnitTest/Infrastructure/ABI/JsonDeserialisation/AbiDeserialiserTests.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AtomicCore.BlockChain.TronNet.Tests.Infrastructure.ABI.JsonDeserialisation;
+
+[TestClass]
+public class AbiDeserialiserTests
+{
+  [TestMethod]
+  public void CanDeserialiseJsonContract()
+  {
+    var contract = new SmartContract();
+    contract.Name = "TestContract";
+    contract.Abi = new SmartContract.Types.ABI();
+    contract.Abi.Entrys.Add(new SmartContract.Types.ABI.Types.Entry()
+    {
+      Anonymous = false,
+      Constant = false,
+      Name = "TestFunction",
+      Payable = false,
+      Type = SmartContract.Types.ABI.Types.Entry.Types.EntryType.Function,
+      Inputs = { new SmartContract.Types.ABI.Types.Entry.Types.Param() { Name = "testInput", Type = "string" } },
+      Outputs = { new SmartContract.Types.ABI.Types.Entry.Types.Param() { Name = "testOutput", Type = "string" } },
+    });
+
+    var entries = contract.Abi.Entrys;
+    var json = JsonSerializer.Serialize(entries, SerializerOptions);
+
+    var testee = new ABIDeserialiser();
+    var abi = testee.DeserialiseContract(json);
+
+    Assert.AreEqual(1, abi.Functions.Length);
+    Assert.AreEqual("testInput", abi.Functions[0].InputParameters[0].Name);
+    Assert.AreEqual("string", abi.Functions[0].InputParameters[0].Type);
+    Assert.AreEqual("testOutput", abi.Functions[0].OutputParameters[0].Name);
+    Assert.AreEqual("string", abi.Functions[0].OutputParameters[0].Type);
+  }
+
+  private JsonSerializerOptions SerializerOptions => new()
+  {
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+  };
+}


### PR DESCRIPTION
Deserialization of a contract failed because it was expected that the underlying  type is a list and not an JArrays with the following exception 

```
System.InvalidCastException: Unable to cast object of type 'Newtonsoft.Json.Linq.JArray' to type 'System.Collections.Generic.List`1[System.Object]'.
    at AtomicCore.BlockChain.TronNet.ABIDeserialiser.BuildFunction(IDictionary`2 function) in /Users/reikla/dev/tron/Tron.Net/lib/AtomicCore/AtomicCore.BlockChain.TronNet/Infrastructure/ABI/JsonDeserialisation/ABIDeserialiser.cs:line 103
   at AtomicCore.BlockChain.TronNet.ABIDeserialiser.DeserialiseContractBody(List`1 contract) in /Users/reikla/dev/tron/Tron.Net/lib/AtomicCore/AtomicCore.BlockChain.TronNet/Infrastructure/ABI/JsonDeserialisation/ABIDeserialiser.cs:line 164
   at AtomicCore.BlockChain.TronNet.ABIDeserialiser.DeserialiseContract(String abi) in /Users/reikla/dev/tron/Tron.Net/lib/AtomicCore/AtomicCore.BlockChain.TronNet/Infrastructure/ABI/JsonDeserialisation/ABIDeserialiser.cs:line 147
   at AtomicCore.BlockChain.TronNet.Tests.Infrastructure.ABI.JsonDeserialisation.AbiDeserialiserTests.CanDeserialiseJsonContract()
```

Therefore a converter was added.

Included a unittest

